### PR TITLE
Fixing Connecting Blocks

### DIFF
--- a/behavior_packs/Avatar_Pack_B/functions/equipment.mcfunction
+++ b/behavior_packs/Avatar_Pack_B/functions/equipment.mcfunction
@@ -9,6 +9,8 @@ execute as @a[hasitem={item=fmh:rabbit_coat_splotched_mask,location=slot.armor.h
 execute as @a[hasitem={item=fmh:rabbit_coat_white_mask,location=slot.armor.head}] at @s run effect @s jump_boost 15 2 true
 execute as @a[hasitem={item=fables_avatars:diving_helmet_mask,location=slot.armor.head}] at @s if block ~ ~1 ~ water run effect @s conduit_power 15 0 true
 execute as @a[hasitem={item=fables_misc:goldglass,location=slot.armor.head}] at @s run effect @s village_hero 15 0 true
-execute as @a[hasitem={item=fables_avatars:mining_helmet,location=slot.armor.head}] at @s run effect @s haste 15 2 true
-execute as @a at @s run fill  ~-10 ~-10 ~-10 ~10 ~10 ~10 air replace light_block_15
+execute as @a[hasitem={item=fables_avatars:mining_helmet,location=slot.armor.head}] at @s run effect @s haste 15 1 true
+
+execute as @a at @s run fill  ~-16 ~-10 ~-16 ~16 ~10 ~16 air replace light_block_9
+execute as @a at @s run fill  ~-16 ~-10 ~-16 ~16 ~10 ~16 air replace light_block_15
 execute as @a[hasitem={item=fables_avatars:mining_helmet,location=slot.armor.head}] at @s run fill  ~ ~1 ~ ~ ~1 ~ light_block_15 replace air

--- a/behavior_packs/Avatar_Pack_B/functions/equipment.mcfunction
+++ b/behavior_packs/Avatar_Pack_B/functions/equipment.mcfunction
@@ -13,4 +13,4 @@ execute as @a[hasitem={item=fables_avatars:mining_helmet,location=slot.armor.hea
 
 execute as @a at @s run fill  ~-16 ~-10 ~-16 ~16 ~10 ~16 air replace light_block_9
 execute as @a at @s run fill  ~-16 ~-10 ~-16 ~16 ~10 ~16 air replace light_block_15
-execute as @a[hasitem={item=fables_avatars:mining_helmet,location=slot.armor.head}] at @s run fill  ~ ~1 ~ ~ ~1 ~ light_block_15 replace air
+execute as @a[hasitem={item=fables_avatars:mining_helmet,location=slot.armor.head}] unless entity @s[hasitem={item=firework_rocket,location=slot.weapon.mainhand}] at @s run fill  ~ ~1 ~ ~ ~1 ~ light_block_15 replace air

--- a/behavior_packs/EB/worldgen/jigsaw_structures/goblin_village.json
+++ b/behavior_packs/EB/worldgen/jigsaw_structures/goblin_village.json
@@ -30,7 +30,12 @@
     "terrain_adaptation": "beard_box",
     "start_pool": "korbon:goblin_well_center",
     "max_depth": 4,
-    "start_height": 0,
+    "start_height": {
+      "type": "constant",
+      "value": {
+        "absolute": 0
+      }
+    },
     "heightmap_projection": "world_surface"
   }
 }

--- a/behavior_packs/MFV6.3_BP/scripts/MF6/Mf6Main.js
+++ b/behavior_packs/MFV6.3_BP/scripts/MF6/Mf6Main.js
@@ -149,59 +149,59 @@ world.beforeEvents.worldInitialize.subscribe((e) => {
 // 		e.dimension.spawnItem(new ItemStack("minecraft:cookie", quantity), block.center());
 // 	}
 // });
-function UpdateBlockConnection(block) {
-	const states = block.permutation.getAllStates();
-	let prefix = "";
-	if (!block.typeId.includes("fence") && !block.typeId.includes("hedge") && !block.typeId.includes("bars_0")) return;
-	for (const stateName in states) {
-		if (stateName.includes(":n") || stateName.includes(":s") || stateName.includes(":w") || stateName.includes(":e")) {
-			prefix = stateName.split(":")[0];
-			break;
-		}
-	}
-	if (!prefix) return;
-	for (const direction in directions) {
-		const offset = directions[direction];
-		const adjacentBlock = block.offset(offset);
-		const shouldConnect = shouldBlockConnect(adjacentBlock);
-		const stateName = `${prefix}:${direction[0]}`;
+// function UpdateBlockConnection(block) {
+// 	const states = block.permutation.getAllStates();
+// 	let prefix = "";
+// 	if (!block.typeId.includes("fence") && !block.typeId.includes("hedge") && !block.typeId.includes("bars_0")) return;
+// 	for (const stateName in states) {
+// 		if (stateName.includes(":n") || stateName.includes(":s") || stateName.includes(":w") || stateName.includes(":e")) {
+// 			prefix = stateName.split(":")[0];
+// 			break;
+// 		}
+// 	}
+// 	if (!prefix) return;
+// 	for (const direction in directions) {
+// 		const offset = directions[direction];
+// 		const adjacentBlock = block.offset(offset);
+// 		const shouldConnect = shouldBlockConnect(adjacentBlock);
+// 		const stateName = `${prefix}:${direction[0]}`;
 
-		if (stateName in states) {
-			block.setPermutation(block.permutation.withState(stateName, shouldConnect ? 1 : 0));
-		}
-	}
-}
-function updateAdjacentBlocksIfNeeded(block) {
-	try {
-		for (const direction in directions) {
-			const offset = directions[direction];
-			const adjacentBlock = block.offset(offset);
-			UpdateBlockConnection(adjacentBlock);
-		}
-	} catch (error) {}
-}
-world.afterEvents.playerPlaceBlock.subscribe((e) => {
-	const { block } = e;
-	updateAdjacentBlocksIfNeeded(block);
-});
-world.afterEvents.playerBreakBlock.subscribe((e) => {
-	const { block } = e;
-	updateAdjacentBlocksIfNeeded(block);
-});
-world.afterEvents.blockExplode.subscribe((e) => {
-	const { block } = e;
-	updateAdjacentBlocksIfNeeded(block);
-});
-class MfBlockConnection {
-	onPlace(e) {
-		const { block } = e;
-		UpdateBlockConnection(block);
-		updateAdjacentBlocksIfNeeded(block);
-	}
-}
-function shouldBlockConnect(block) {
-	return block.hasTag("is_solid") || block.hasTag("block_conection") ||
-		(solidBlocks.some(connect => block.typeId.includes(connect)) &&
-		!blockException.some(exception => block.typeId.includes(exception)) &&
-		block.typeId.includes("minecraft:"));
-}
+// 		if (stateName in states) {
+// 			block.setPermutation(block.permutation.withState(stateName, shouldConnect ? 1 : 0));
+// 		}
+// 	}
+// }
+// function updateAdjacentBlocksIfNeeded(block) {
+// 	try {
+// 		for (const direction in directions) {
+// 			const offset = directions[direction];
+// 			const adjacentBlock = block.offset(offset);
+// 			UpdateBlockConnection(adjacentBlock);
+// 		}
+// 	} catch (error) {}
+// }
+// world.afterEvents.playerPlaceBlock.subscribe((e) => {
+// 	const { block } = e;
+// 	updateAdjacentBlocksIfNeeded(block);
+// });
+// world.afterEvents.playerBreakBlock.subscribe((e) => {
+// 	const { block } = e;
+// 	updateAdjacentBlocksIfNeeded(block);
+// });
+// world.afterEvents.blockExplode.subscribe((e) => {
+// 	const { block } = e;
+// 	updateAdjacentBlocksIfNeeded(block);
+// });
+// class MfBlockConnection {
+// 	onPlace(e) {
+// 		const { block } = e;
+// 		UpdateBlockConnection(block);
+// 		updateAdjacentBlocksIfNeeded(block);
+// 	}
+// }
+// function shouldBlockConnect(block) {
+// 	return block.hasTag("is_solid") || block.hasTag("block_conection") ||
+// 		(solidBlocks.some(connect => block.typeId.includes(connect)) &&
+// 		!blockException.some(exception => block.typeId.includes(exception)) &&
+// 		block.typeId.includes("minecraft:"));
+// }

--- a/behavior_packs/MFV7.0_BP/blocks/mf/book_shelves/dark_oak_bookshelf.json
+++ b/behavior_packs/MFV7.0_BP/blocks/mf/book_shelves/dark_oak_bookshelf.json
@@ -131,7 +131,7 @@
 				}
 			},
 			"minecraft:material_instances": {
-				"*": {"texture": "mf:darkoak_bookshelf_0","render_method": "alpha_test"},
+				"*": {"texture": "mf:dark_oak_bookshelf_0","render_method": "alpha_test"},
 				"book": {"texture": "mf:book_brown","render_method": "alpha_test"},
 				"potion": {"texture": "mf:potion_bookshelf","render_method": "alpha_test"},
 				"potion_1": {"texture": "mf:potion_bookshelf_1","render_method": "alpha_test"},


### PR DESCRIPTION
- Fixed the issue with connecting blocks not updating adjacent blocks (hedges, fences, bars)
- Prevented the Mining Helmet from leaving light blocks when holding a rocket
- Fixed Textures & Model for Dark Oak Bookshelf
- Goblin Village should now generate in Dark Oak Forests again.