### PR TITLE
Disable Mailboxes

### DIFF
--- a/world_behavior_packs.json
+++ b/world_behavior_packs.json
@@ -55,10 +55,10 @@
 	},
 		
 
-	{
-		"pack_id" : "3a36b38b-3e54-4cb4-b99d-139e1c275901",  //Mailboxes
-		"version" : [ 1, 2, 2 ]
-	},
+	// {
+	// 	"pack_id" : "3a36b38b-3e54-4cb4-b99d-139e1c275901",  //Mailboxes
+	// 	"version" : [ 1, 2, 2 ]
+	// },
 	{
 		"pack_id" : "95cc40f0-999b-49b8-8311-c8aaaa887ed6", //MrCrayFish Furniture
 		"version" : [ 1, 2, 82 ]

--- a/world_resource_packs.json
+++ b/world_resource_packs.json
@@ -1,11 +1,6 @@
 
 [
 	{
-		"pack_id" : "883172a3-6049-4c62-8d26-fc17395b1095", //Alycia's Avancements
-		"version" : [ 2, 3, 0 ]
-	},
-	
-	{
 		"pack_id" : "98836a6c-fe16-60f4-87a4-5afb6439bd9f", //Farmers' Delight
 		"version" : [ 3, 2, 1 ]
 	},
@@ -58,10 +53,10 @@
 		"version" : [ 6, 4, 4 ]
 	},
 	
-	{
-		"pack_id" : "9a4bc60d-9e2e-4638-b93b-9b354bb6c64b", //Mailboxes
-		"version" : [ 1, 2, 3	 ]
-	},
+	// {
+	// 	"pack_id" : "9a4bc60d-9e2e-4638-b93b-9b354bb6c64b", //Mailboxes
+	// 	"version" : [ 1, 2, 3	 ]
+	// },
 	
 	{
 		"pack_id" : "43120e01-773d-4667-a1cd-fb5d6fb84543", //Fables Glass Pack


### PR DESCRIPTION
Throughout extensive testing and troubleshooting, I discovered that by disabling the mailboxes addon, our average TPS (Ticks Per Second), went from 9TPS to about 18 TPS. The maximum is 20. Looking at the number of mailboxes in the database, I can see that this isn't something we really use like we did back in AthosCraft Season 6, so I'm making the decision to remove this Addon from the server.

This change disables and removes the Mailboxes Addon. Existing blocks placed in the world will appear as Update blocks, and can be destroyed if you see them.